### PR TITLE
DM-11320

### DIFF
--- a/python/lsst/synpipe/positionGalSimFakes.py
+++ b/python/lsst/synpipe/positionGalSimFakes.py
@@ -241,9 +241,7 @@ class PositionGalSimFakesTask(BaseFakeSourcesTask):
                                             PARENT)
                 galBBox = newBBox
 
-            # Add Noise: Optional?
-            galMaskedImage = fsl.addNoise(galImage, exposure.getDetector(),
-                                          rand_gen=self.npRand)
+            galMaskedImage = lsst.afw.image.MaskedImageF(galImage)
 
             # Put information of the added fake galaxies into the header
             md.set("FAKE%s" % str(galident), "%.3f, %.3f" % (galXY.getX(),

--- a/python/lsst/synpipe/positionStarFakes.py
+++ b/python/lsst/synpipe/positionStarFakes.py
@@ -90,9 +90,7 @@ class PositionStarFakesTask(BaseFakeSourcesTask):
                 starImage = starImage.Factory(starImage, newBBox, PARENT)
                 starBBox = newBBox
 
-            starMaskedImage = fsl.addNoise(starImage.convertF(),
-                                           exposure.getDetector(),
-                                           rand_gen=self.npRand)
+            starMaskedImage = afwImage.MaskedImageF(starImage)
 
             starMaskedImage.getMask().set(self.bitmask)
 

--- a/python/lsst/synpipe/randomGalSimFakes.py
+++ b/python/lsst/synpipe/randomGalSimFakes.py
@@ -100,7 +100,8 @@ class RandomGalSimFakesTask(BaseFakeSourcesTask):
                 galImage = galImage.Factory(galImage, newBBox, lsst.afw.image.PARENT)
                 galBBox = newBBox
 
-            galMaskedImage = fsl.addNoise(galImage, exposure.getDetector(), rand_gen=self.npRand)
+            galMaskedImage = lsst.afw.image.MaskedImageF(galImage)
+
             mask = galMaskedImage.getMask()
             mask.set(self.bitmask)
 

--- a/python/lsst/synpipe/randomStarFakes.py
+++ b/python/lsst/synpipe/randomStarFakes.py
@@ -51,7 +51,8 @@ class RandomStarFakeSourcesTask(BaseFakeSourcesTask):
             self.log.info("Adding fake at: %.1f,%.1f" % (x, y))
             psfImage = psf.computeImage(lsst.afw.geom.Point2D(x, y))
             psfImage *= flux
-            psfMaskedImage = fsl.addNoise(psfImage.convertF(), exposure.getDetector(), rand_gen=self.npRand)
+
+            psfMaskedImage = lsst.afw.image.MaskedImageF(psfImage.convertF())
 
             mask = psfMaskedImage.getMask()
             mask.set(self.bitmask)


### PR DESCRIPTION
Images processed using the LSST software stack are expected to be
background noise dominated for faint objects. As such their is no
reason to add additional noise to fake objects inserted. This also
takes care of a problem where the noise being inserted was
artificially too large due to a bug where the gain was not taken
into account