### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/bin.src/makeSourceList.py
+++ b/bin.src/makeSourceList.py
@@ -55,7 +55,7 @@ class MakeFakeInputsTask(pipeBase.CmdLineTask):
     _DefaultName = 'makeFakeInputs'
     ConfigClass = MakeFakeInputsConfig
 
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """Make input catalogs."""
         skyMap = dataRef.get('deepCoadd_skyMap', immediate=True)
         tractId = dataRef.dataId['tract']

--- a/bin.src/makeSourceListGrid.py
+++ b/bin.src/makeSourceListGrid.py
@@ -193,7 +193,7 @@ class MakeFakeInputsTask(pipeBase.CmdLineTask):
     _DefaultName = 'makeFakeInputs'
     ConfigClass = MakeFakeInputsConfig
 
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         skyMap = dataRef.get('deepCoadd_skyMap', immediate=True)
         tractId = dataRef.dataId['tract']
         tract = skyMap[tractId]

--- a/python/lsst/synpipe/mergeOnlyFakes.py
+++ b/python/lsst/synpipe/mergeOnlyFakes.py
@@ -26,7 +26,7 @@ class OnlyFakesMergeTask(mBand.MeasureMergedCoaddSourcesTask):
     # OnlyFakesMergeConfig to avoid having to fix overridden config parameters
     ConfigClass = mBand.MeasureMergedCoaddSourcesConfig
 
-    def run(self, patchRef):
+    def runDataRef(self, patchRef):
         """Measure and deblend"""
 
         exposure = patchRef.get(self.config.coaddName + "Coadd", immediate=True)


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
